### PR TITLE
Fixing Talon FX Not Logging Azimuth and Position Joint correctly

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/azimuth_motor/AzimuthMotorIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/drive/azimuth_motor/AzimuthMotorIOTalonFX.java
@@ -72,6 +72,7 @@ public class AzimuthMotorIOTalonFX implements AzimuthMotorIO {
   private final Alert encoderAlert;
 
   private double positionSetpoint = 0.0;
+  private double velocitySetpoint = 0.0;
 
   private final Queue<Double> timestampQueue;
   private final Queue<Double> turnPositionQueue;
@@ -238,7 +239,8 @@ public class AzimuthMotorIOTalonFX implements AzimuthMotorIO {
     inputs.rotorPositionRotations = rotorPosition.getValueAsDouble();
     inputs.velocityRotationsPerSecond = velocity.getValueAsDouble();
 
-    inputs.desiredVelocityRotationsPerSecond = positionSetpoint;
+    inputs.desiredVelocityRotationsPerSecond = velocitySetpoint;
+    inputs.desiredPositionRotations = positionSetpoint;
 
     for (int i = 0; i < motors.length; i++) {
       // Do not refresh the three status signals above
@@ -300,6 +302,7 @@ public class AzimuthMotorIOTalonFX implements AzimuthMotorIO {
   @Override
   public void setPosition(double position, double velocity) {
     positionSetpoint = position;
+    velocitySetpoint = velocity;
 
     motors[0].setControl(positionRequest.withPosition(position).withVelocity(velocity));
   }

--- a/src/main/java/frc/robot/subsystems/position_joint/PositionJointIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/position_joint/PositionJointIOTalonFX.java
@@ -72,6 +72,7 @@ public class PositionJointIOTalonFX implements PositionJointIO {
   private final Alert encoderAlert;
 
   private double positionSetpoint = 0.0;
+  private double velocitySetpoint = 0.0;
 
   public PositionJointIOTalonFX(
       String name, PositionJointHardwareConfig config, DoubleSupplier externalFeedforward) {
@@ -236,6 +237,7 @@ public class PositionJointIOTalonFX implements PositionJointIO {
     inputs.velocity = velocity.getValueAsDouble();
 
     inputs.desiredVelocity = positionSetpoint;
+    inputs.desiredVelocity = velocitySetpoint;
 
     for (int i = 0; i < motors.length; i++) {
       // Do not refresh the three status signals above
@@ -286,6 +288,7 @@ public class PositionJointIOTalonFX implements PositionJointIO {
   @Override
   public void setPosition(double position, double velocity) {
     positionSetpoint = position;
+    velocitySetpoint = velocity;
 
     motors[0].setControl(
         positionRequest


### PR DESCRIPTION
- Added desired velocity logs in Position Joint and Azimuth using TalonFX motor controllers.
- Fixed desired position log for Azimuth using TalonFX motor controllers.